### PR TITLE
Add Vitest setup and cn utility tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.1.7",
@@ -36,6 +37,7 @@
     "tailwindcss": "^4.1.7",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.3.0",
-    "vite": "^5.4.2"
+    "vite": "^5.4.2",
+    "vitest": "^1.5.0"
   }
 }

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest'
+import { cn } from './utils'
+
+describe('cn', () => {
+  it('merges simple class strings', () => {
+    expect(cn('foo', 'bar')).toBe('foo bar')
+  })
+
+  it('ignores falsy values', () => {
+    expect(cn('foo', false && 'bar', undefined, 'baz')).toBe('foo baz')
+  })
+
+  it('handles conditional classes', () => {
+    expect(cn('foo', { bar: true, baz: false })).toBe('foo bar')
+  })
+})

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,6 +2,7 @@ import path from "path";
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
+import { configDefaults } from "vitest/config";
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -13,5 +14,10 @@ export default defineConfig({
   },
   optimizeDeps: {
     exclude: ["lucide-react"],
+  },
+  test: {
+    globals: true,
+    environment: "jsdom",
+    exclude: [...configDefaults.exclude, "dist/**"],
   },
 });


### PR DESCRIPTION
## Summary
- add vitest to dev dependencies and create `test` script
- configure vitest in Vite config
- add unit test for `cn` utility

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68516adb8424832f96cdde03357abfe0